### PR TITLE
global: WireGuard always has a capital G and capital W

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ version 0.6.1:
 - [bugfix] old connection not killed after network change detected (in rare cases)
 
 version 0.6.0:
-- [new] support for Wireguard
+- [new] support for WireGuard
 - [new] cli-interface
 - [change] additional parameters parsed from .desktop-files
 - [change] update routine now uses dpkg/rpm if installed as DEB/RPM package - reinstall required!
@@ -48,7 +48,7 @@ version 0.5.0:
 - [bugfix] Crashes when modifying server during latency check
 - [bugfix] Changing country in modify dialog fails
 - [bugfix] Connection attempt fails when protocol/port not set
-- [bugfix] Wireguard servers downloaded from Mullvad even though not supported
+- [bugfix] WireGuard servers downloaded from Mullvad even though not supported
 
 version 0.4.1:
 - [bugfix] Crashes if no port/protocol selected

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Qomui (Qt OpenVPN Management UI) is an easy-to-use OpenVPN Gui for GNU/Linux wit
 - protection against DNS leaks/ipv6 leaks
 - iptables-based, configurable firewall that blocks all outgoing network traffic in case the VPN connection breaks down
 - allow applications to bypass the VPN tunnel - to watch Netflix for example
-- experimental support for Wireguard
+- experimental support for WireGuard
 - command-line interface
 
 ### Screenshots
@@ -78,8 +78,8 @@ cgexec -g net_cls:bypass_qomui $yourcommand
 ```
 The idea is taken from [this post on severfault.com](https://serverfault.com/questions/669430/how-to-bypass-openvpn-per-application/761780#761780). Essentially, running an application outside the OpenVPN tunnel works by putting it in a network control group. This allows classifying and identifying network packets from processes in this cgroup in order to route them differently. Be aware that the implementation of this feature is still experimental. 
 
-### Wireguard
-You can add Wireguard config files from any provider as easily as OpenVPN files. Wireguard configs for Mullvad are now downloaded automatically alongside their OpenVPN configs as long as Wireguard is installed. If you choose to manually import Wireguard config files, Qomui will automatically recognize the type of file. As of now, Wireguard will not be installed automatically with DEB and RPM packages. You can find the official installation guidelines for different distributions [here](https://www.wireguard.com/install/).
+### WireGuard
+You can add WireGuard config files from any provider as easily as OpenVPN files. WireGuard configs for Mullvad are now downloaded automatically alongside their OpenVPN configs as long as WireGuard is installed. If you choose to manually import WireGuard config files, Qomui will automatically recognize the type of file. As of now, WireGuard will not be installed automatically with DEB and RPM packages. You can find the official installation guidelines for different distributions [here](https://www.wireguard.com/install/).
 
 ### Cli
 The cli interface is still experimental and missing some features, e.g. automatic reconnects. Avoid using the cli and the Gui concurrently. 

--- a/qomui/qomui_gui.py
+++ b/qomui/qomui_gui.py
@@ -111,7 +111,7 @@ class QomuiGui(QtWidgets.QWidget):
     bypass_dict = {}
     config_dict = {}
     packetmanager = None
-    tunnel_list = ["OpenVPN", "Wireguard"]
+    tunnel_list = ["OpenVPN", "WireGuard"]
     config_list = [
                    "firewall",
                    "autoconnect",
@@ -1409,8 +1409,8 @@ class QomuiGui(QtWidgets.QWidget):
             elif v["provider"] not in self.provider_list:
                 self.provider_list.append(v["provider"])
             try:
-                if v["tunnel"] == "Wireguard" and "Wireguard" not in self.tunnel_list:
-                    self.tunnel_list.append("Wireguard")
+                if v["tunnel"] == "WireGuard" and "WireGuard" not in self.tunnel_list:
+                    self.tunnel_list.append("WireGuard")
                     for t in self.tunnel_list:
                         self.tunnelBox.addItem(t)
                     self.tunnelBox.setVisible(True)
@@ -1530,7 +1530,7 @@ class QomuiGui(QtWidgets.QWidget):
                             if tunnel == "OpenVPN":
                                 self.serverListWidget.setRowHidden(index, False)
                                 getattr(self, key).setHidden(False)
-                            elif tunnel == "Wireguard":
+                            elif tunnel == "WireGuard":
                                 self.serverListWidget.setRowHidden(index, True)
                                 getattr(self, key).setHidden(True)
                     else:
@@ -1566,7 +1566,7 @@ class QomuiGui(QtWidgets.QWidget):
                             val["city"], fav=fav)
             
         try:
-            if val["tunnel"] == "Wireguard":
+            if val["tunnel"] == "WireGuard":
                 getattr(self, key).hide_button(0)
         except KeyError:
             pass
@@ -1724,7 +1724,7 @@ class QomuiGui(QtWidgets.QWidget):
             self.ovpn_dict = utils.create_server_dict(current_dict, self.protocol_dict)
             
             try:
-                if self.ovpn_dict["tunnel"] == "Wireguard":
+                if self.ovpn_dict["tunnel"] == "WireGuard":
                     self.delete_hop()
             except KeyError:
                 pass
@@ -2745,7 +2745,7 @@ class ModifyServer(QtWidgets.QDialog):
     
     def load_config_file(self):
         try:
-            if self.server_info["tunnel"] == "Wireguard":
+            if self.server_info["tunnel"] == "WireGuard":
                 self.configBrowser.setVisible(False)
                 self.configLabel.setVisible(False)
                 self.changeAllBox.setVisible(False)

--- a/qomui/qomui_service.py
+++ b/qomui/qomui_service.py
@@ -453,7 +453,7 @@ class QomuiDbus(dbus.service.Object):
             pass
         
         try:
-            if self.ovpn_dict["tunnel"] == "Wireguard":
+            if self.ovpn_dict["tunnel"] == "WireGuard":
                 self.wireguard()
             else:
                 self.openvpn()

--- a/qomui/update.py
+++ b/qomui/update.py
@@ -314,7 +314,7 @@ class MullvadDownload(QtCore.QThread):
                                                                 "ip" : ip,
                                                                 "port" : port,
                                                                 "public_key" : public_key,
-                                                                "tunnel" : "Wireguard"}
+                                                                "tunnel" : "WireGuard"}
                                     
                     
                     private_key = check_output(["wg", "genkey"]).decode("utf-8").split("\n")[0]
@@ -699,9 +699,9 @@ class AddFolder(QtCore.QThread):
                         protocol = line.split(" ")[1]
                         proto_line = 1
                     
-                    #Wireguard
+                    #WireGuard
                     elif line.startswith("Endpoint ="):
-                        tunnel = "Wireguard"
+                        tunnel = "WireGuard"
                         ip_port = line.split(" = ")[1]
                         ipsearch = re.compile('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
                         result = ipsearch.search(line)

--- a/qomui/utils.py
+++ b/qomui/utils.py
@@ -49,7 +49,7 @@ def create_server_dict(current_dict, protocol_dict):
         
         elif provider == "Mullvad":
             try:
-                if current_dict["tunnel"] == "Wireguard":
+                if current_dict["tunnel"] == "WireGuard":
                     current_dict.update({"port": "51820", "protocol": "UDP"})
                 else:
                     current_dict.update({"port": port, "protocol": protocol, "prot_index": mode})


### PR DESCRIPTION
Calling it "Wireguard" is never correct.