### PR TITLE
update: remove unused variable

### DIFF
--- a/qomui/update.py
+++ b/qomui/update.py
@@ -241,7 +241,6 @@ class AirVPNDownload(QtCore.QThread):
 class MullvadDownload(QtCore.QThread):
      down_finished = QtCore.pyqtSignal(object)
      importFail = QtCore.pyqtSignal(str)
-     omit = ["brigde", "wireguard"]
     
      def __init__(self, accountnumber):
         QtCore.QThread.__init__(self)


### PR DESCRIPTION
"brigde" was spelled wrong, but actually `omit` didn't appear to be used.