### PR TITLE
Don't use subprocess to calculate current user / group

### DIFF
--- a/qomui/utils.py
+++ b/qomui/utils.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from subprocess import check_output
+import grp
+import getpass
+import pwd
 
 SUPPORTED_PROVIDERS = ["Airvpn", "Mullvad", "ProtonVPN", "PIA", "Windscribe"]
 
 def get_user_group():
-    user = check_output(['id', '-u', '-n']).decode("utf-8").split("\n")[0]
-    group = check_output(['id', '-g', '-n']).decode("utf-8").split("\n")[0]
-    return {"user" : user, "group" : group}
+    username = getpass.getuser()
+    group = grp.getgrgid(pwd.getpwnam(username).pw_gid).gr_name
+    return {"user" : username, "group" : group}
 
 def create_server_dict(current_dict, protocol_dict):
     provider = current_dict["provider"]


### PR DESCRIPTION
Use builtin python libraries to parse the user / group databases directly, rather than shelling out to `id` to do it. These are all in the standard libraries, so don't require additional dependencies, and look to be supported by all versions of Python. I tested the commands in a 3.7 shell, and they looked to work fine.