### PR TITLE
Use non-strict mode for ConfigParser

### DIFF
--- a/qomui/widgets.py
+++ b/qomui/widgets.py
@@ -893,7 +893,7 @@ class AppSelector(QtWidgets.QDialog):
                 for f in os.listdir(d):
                     if f.endswith(".desktop"):
                         desktop_file = os.path.join(d, f)
-                        c = configparser.ConfigParser()
+                        c = configparser.ConfigParser(strict=False)
                         c.read(desktop_file)
 
                         try:


### PR DESCRIPTION
Fixes #141 

If the user has a `.desktop` file that is invalid we need to be able to catch for that. Using non-strict mode for ConfigParser fixes this.

![Screenshot from 2020-03-20 16-34-49](https://user-images.githubusercontent.com/24727492/77211656-43b38d00-6aca-11ea-8f70-bbd00feb4b9b.png)
