### PR TITLE
fix typo: initalize -> initialize

### DIFF
--- a/qomui/qomui_gui.py
+++ b/qomui/qomui_gui.py
@@ -118,10 +118,10 @@ class QomuiGui(QtWidgets.QWidget):
                                 )
 
             if ret == 0:
-                self.initalize_service("enable", "--now")
+                self.initialize_service("enable", "--now")
 
             elif ret == 1:
-                self.initalize_service("start")
+                self.initialize_service("start")
 
             elif ret == 2:
                 sys.exit(1)


### PR DESCRIPTION
fixing this error I got using qomui while enabling the service at startup:

    AttributeError: 'QomuiGui' object has no attribute 'initalize_service'. Did you mean: 'initialize_service'?